### PR TITLE
Fix the Vapor version to pre async/await state ...

### DIFF
--- a/00-book-server/Package.swift
+++ b/00-book-server/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
 	name: "BookServer",
 	platforms: [
-	   .macOS(.v10_15)
+		.macOS(.v10_15)
 	],
 	dependencies: [
 		// 💧 A server-side Swift web framework.

--- a/00-book-server/Package.swift
+++ b/00-book-server/Package.swift
@@ -1,25 +1,25 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
-    name: "BookServer",
-    platforms: [
-       .macOS(.v10_15)
-    ],
-    dependencies: [
-        // 💧 A server-side Swift web framework.
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-    ],
-    targets: [
-        .target(
-            name: "App",
-            dependencies: [
-                .product(name: "Vapor", package: "vapor")
-            ],
-            swiftSettings: [
-                .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
-            ]
-        ),
-        .target(name: "Run", dependencies: [.target(name: "App")])
-    ]
+	name: "BookServer",
+	platforms: [
+	   .macOS(.v10_15)
+	],
+	dependencies: [
+		// 💧 A server-side Swift web framework.
+		.package(url: "https://github.com/vapor/vapor.git", .exact("4.49.0")),
+	],
+	targets: [
+		.target(
+			name: "App",
+			dependencies: [
+				.product(name: "Vapor", package: "vapor")
+			],
+			swiftSettings: [
+				.unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
+			]
+		),
+		.executableTarget(name: "Run", dependencies: [.target(name: "App")])
+	]
 )

--- a/00-book-server/Package.swift
+++ b/00-book-server/Package.swift
@@ -2,24 +2,24 @@
 import PackageDescription
 
 let package = Package(
-	name: "BookServer",
-	platforms: [
-		.macOS(.v10_15)
-	],
-	dependencies: [
-		// 💧 A server-side Swift web framework.
-		.package(url: "https://github.com/vapor/vapor.git", .exact("4.49.0")),
-	],
-	targets: [
-		.target(
-			name: "App",
-			dependencies: [
-				.product(name: "Vapor", package: "vapor")
-			],
-			swiftSettings: [
-				.unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
-			]
-		),
-		.executableTarget(name: "Run", dependencies: [.target(name: "App")])
-	]
+  name: "BookServer",
+  platforms: [
+    .macOS(.v10_15)
+  ],
+  dependencies: [
+    // 💧 A server-side Swift web framework.
+    .package(url: "https://github.com/vapor/vapor.git", .exact("4.49.0")),
+  ],
+  targets: [
+    .target(
+      name: "App",
+      dependencies: [
+        .product(name: "Vapor", package: "vapor")
+      ],
+      swiftSettings: [
+        .unsafeFlags(["-cross-module-optimization"], .when(configuration: .release))
+      ]
+    ),
+    .executableTarget(name: "Run", dependencies: [.target(name: "App")])
+  ]
 )


### PR DESCRIPTION
... because swift 5.5.2 compiles a crashing binary otherwise on pre macOS 12.

It'd be nice to merge this into 1.0