### PR TITLE
Update Vapor dependency to 4.62.1

### DIFF
--- a/00-book-server/Package.swift
+++ b/00-book-server/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
   ],
   dependencies: [
     // 💧 A server-side Swift web framework.
-    .package(url: "https://github.com/vapor/vapor.git", .exact("4.49.0")),
+    .package(url: "https://github.com/vapor/vapor.git", .exact("4.62.1")),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Updating Vapor to 4.62.1 resolves build issues on Xcode 14/Swift 5.7. My Mac is now Ventura, so I cannot check backwards compatibility.