### PR TITLE
[hold] Moves the countdown method to main actor

### DIFF
--- a/04-async-streams/projects/challenge/Blabber/Model/BlabberModel.swift
+++ b/04-async-streams/projects/challenge/Blabber/Model/BlabberModel.swift
@@ -51,7 +51,7 @@ class BlabberModel: ObservableObject {
   }
 
   /// Does a countdown and sends the message.
-  func countdown(to message: String) async throws {
+  @MainActor func countdown(to message: String) async throws {
     guard !message.isEmpty else { return }
     var countdown = 3
     let counter = AsyncStream<String> {

--- a/04-async-streams/projects/final/Blabber/Model/BlabberModel.swift
+++ b/04-async-streams/projects/final/Blabber/Model/BlabberModel.swift
@@ -51,7 +51,7 @@ class BlabberModel: ObservableObject {
   }
 
   /// Does a countdown and sends the message.
-  func countdown(to message: String) async throws {
+  @MainActor func countdown(to message: String) async throws {
     guard !message.isEmpty else { return }
 
     let counter = AsyncStream<String> { continuation in

--- a/04-async-streams/projects/starter/Blabber/Model/BlabberModel.swift
+++ b/04-async-streams/projects/starter/Blabber/Model/BlabberModel.swift
@@ -51,7 +51,7 @@ class BlabberModel: ObservableObject {
   }
 
   /// Does a countdown and sends the message.
-  func countdown(to message: String) async throws {
+  @MainActor func countdown(to message: String) async throws {
     guard !message.isEmpty else { return }
   }
 

--- a/05-intermediate-async-await/projects/final/Blabber/Model/BlabberModel.swift
+++ b/05-intermediate-async-await/projects/final/Blabber/Model/BlabberModel.swift
@@ -84,7 +84,7 @@ class BlabberModel: ObservableObject {
   }
 
   /// Does a countdown and sends the message.
-  func countdown(to message: String) async throws {
+  @MainActor func countdown(to message: String) async throws {
     guard !message.isEmpty else { return }
     var countdown = 3
     let counter = AsyncStream<String> {

--- a/05-intermediate-async-await/projects/starter/Blabber/Model/BlabberModel.swift
+++ b/05-intermediate-async-await/projects/starter/Blabber/Model/BlabberModel.swift
@@ -55,7 +55,7 @@ class BlabberModel: ObservableObject {
   }
 
   /// Does a countdown and sends the message.
-  func countdown(to message: String) async throws {
+  @MainActor func countdown(to message: String) async throws {
     guard !message.isEmpty else { return }
     var countdown = 3
     let counter = AsyncStream<String> {

--- a/06-asynchronous-code-with-task-and-continuation/projects/final/Blabber/Model/BlabberModel.swift
+++ b/06-asynchronous-code-with-task-and-continuation/projects/final/Blabber/Model/BlabberModel.swift
@@ -86,7 +86,7 @@ class BlabberModel: ObservableObject {
   var sleep: (UInt64) async throws -> Void = Task.sleep(nanoseconds:)
 
   /// Does a countdown and sends the message.
-  func countdown(to message: String) async throws {
+  @MainActor func countdown(to message: String) async throws {
     let sleep = self.sleep
     guard !message.isEmpty else { return }
     var countdown = 3

--- a/06-asynchronous-code-with-task-and-continuation/projects/starter/Blabber/Model/BlabberModel.swift
+++ b/06-asynchronous-code-with-task-and-continuation/projects/starter/Blabber/Model/BlabberModel.swift
@@ -84,7 +84,7 @@ class BlabberModel: ObservableObject {
   }
 
   /// Does a countdown and sends the message.
-  func countdown(to message: String) async throws {
+  @MainActor func countdown(to message: String) async throws {
     guard !message.isEmpty else { return }
     var countdown = 3
     let counter = AsyncStream<String> {


### PR DESCRIPTION
In one part of chapter 4 the countdown uses a Timer and in iOS16 sometimes the code ends up off the main thread and timer doesn't work, this PR annotates the method on the main actor