### PR TITLE
Raised Vapor package version number

### DIFF
--- a/00-book-server/Package.swift
+++ b/00-book-server/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
   ],
   dependencies: [
     // 💧 A server-side Swift web framework.
-    .package(url: "https://github.com/vapor/vapor.git", .exact("4.66.1")),
+    .package(url: "https://github.com/vapor/vapor.git", .exact("4.92.1")),
   ],
   targets: [
     .target(


### PR DESCRIPTION
Raised Vapor package version number to `4.92.1` which fixes some build error.